### PR TITLE
Update class-wc-bling-integration.php

### DIFF
--- a/includes/class-wc-bling-integration.php
+++ b/includes/class-wc-bling-integration.php
@@ -194,7 +194,9 @@ class WC_Bling_Integration extends WC_Integration {
 
 					// Get product data.
 					$product = $order->get_product_from_item( $order_item );
-
+					if(!$product){
+						continue;
+					}	
 					// Product with attrs.
 					$item_meta = new WC_Order_Item_Meta( $order_item['item_meta'] );
 					if ( $meta = $item_meta->display( true, true ) ) {
@@ -295,10 +297,10 @@ class WC_Bling_Integration extends WC_Integration {
 			if ( isset( $response_data->retorno->erros ) ) {
 				$errors = array();
 				foreach ( $response_data->retorno->erros as $error ) {
-					if ( isset( $error->msg ) ) {
-						$errors[] = (string) $error->msg;
+					if ( isset( $error->erro->msg ) ) {
+						$errors[] = (string) $error->erro->msg;
 					} else {
-						$msg = (array) $error;
+						$msg = (array) $error->erro;
 						$errors[] = (string) current( $msg );
 					}
 				}


### PR DESCRIPTION
Boa tarde Cláudio.

Um cliente nosso identificou um erro na integração woocommerce.
Quando um produto referenciado a um pedido é excluído permanentemente, a instância $product é null, causando erro na chamada get_sku() quando um pedido é enviado.
Além disso, ajustei a declaração do objeto $erro, incluindo a resposta correta da API do bling.

Verifique a validação assim que possível.

Obrigado.
